### PR TITLE
Prevent != operator registering rest of line as comment

### DIFF
--- a/syntaxes/sqr.json
+++ b/syntaxes/sqr.json
@@ -3,7 +3,7 @@
   "fileTypes": ["sqr"],
   "patterns": [
     {  "name": "comment.block.SQR",
-       "match": "(!).*$\n?",
+       "match": "(!)[^=].*$\n?",
        "comment": "Comments begin with a bang"
     },
     {

--- a/syntaxes/sqr.json
+++ b/syntaxes/sqr.json
@@ -3,7 +3,7 @@
   "fileTypes": ["sqr"],
   "patterns": [
     {  "name": "comment.block.SQR",
-       "match": "(!)[^=].*$\n?",
+       "match": "(!)[^= ].*$\n?",
        "comment": "Comments begin with a bang"
     },
     {


### PR DESCRIPTION
This change **should** prevent != as registering as a comment, while working as intended otherwise.