### PR TITLE
Minor enhancements PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## version 0.2.9 January 22, 2020
+
+Updates by @deathvango
+- Added highlighting for global variables referenced from local procedures (ex $_global-var)
+- Added ".inc" extension as supported SQR filetype
+
 ## version 0.2.8 March 28, 2018
 
 Update to numeric constant regex by @RameshKris

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "SQR",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "publisher": "CityOfEscondido",
     "displayName": "SQR",
     "description": "SQR Language Support (Oracle, PeopleSoft Enterprise)",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
                     ".sqr",
                     ".sqc",
                     ".SQR",
-                    ".SQC"
+                    ".SQC",
+                    ".inc",
+                    ".INC"
                 ],
                 "configuration": "./sqr.configuration.json"
             }

--- a/syntaxes/sqr.json
+++ b/syntaxes/sqr.json
@@ -61,6 +61,10 @@
     {  "name": "variable.name.SQR",
        "match": "(\\$|#|&)([A-Za-z][\\-A-Za-z0-9_]+)"
     },
+    {  
+      "name": "variable.global.name.SQR",
+      "match": "(\\$|#)(_[A-Za-z][\\-A-Za-z0-9_]+)"
+    },
     {  "name": "keyword.operator.SQR",
        "match": "(\\|\\||!=|=|>|<|>=|<=|<>|\\+|\\^|\\*|/|#|%|(\\s(-|not|and|or|xor)\\s))"
     },


### PR DESCRIPTION
Hello,

There were certain missing syntax highlighting pieces in our development environment here at Redstone Consulting Group.

1. One of the dependency libraries we use belong to an organization called Firserv, and they like to add the ".inc" extension to all of their files. I do not know if this is a unique use-case for us only, but I thought that I'd include it since it required us to hack around this extension. I can take it out if you feel it's too specific a modification.

2. We use a lot of local procedures in out SQR reports, so global variables must be referenced using an underscore like so:
```
$_global-var-name
```
These weren't being highlighted so I added an additional rule to address global variables.

Let me know what y'all think and if there are any changes to my PR you'd like to see.

Thanks!